### PR TITLE
In order to function like bitcoin node, ToASM() will append [error]

### DIFF
--- a/bscript/script.go
+++ b/bscript/script.go
@@ -198,9 +198,7 @@ func (s *Script) ToString() string { // TODO: change to HexString?
 // ToASM returns the string ASM opcodes of the script.
 func (s *Script) ToASM() (string, error) {
 	parts, err := DecodeParts(*s)
-	if err != nil {
-		return "", err
-	}
+	// if err != nil, ee will append [error] to the ASM script below.
 
 	var asmScript string
 	for _, p := range parts {
@@ -209,6 +207,10 @@ func (s *Script) ToASM() (string, error) {
 		} else {
 			asmScript = asmScript + " " + hex.EncodeToString(p)
 		}
+	}
+
+	if err != nil {
+		asmScript += " [error]"
 	}
 
 	return strings.TrimSpace(asmScript), nil

--- a/bscript/script.go
+++ b/bscript/script.go
@@ -198,7 +198,7 @@ func (s *Script) ToString() string { // TODO: change to HexString?
 // ToASM returns the string ASM opcodes of the script.
 func (s *Script) ToASM() (string, error) {
 	parts, err := DecodeParts(*s)
-	// if err != nil, ee will append [error] to the ASM script below.
+	// if err != nil, we will append [error] to the ASM script below (as done in the node).
 
 	var asmScript string
 	for _, p := range parts {

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -2,6 +2,7 @@ package bscript_test
 
 import (
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/bitcoinsv/bsvd/bsvec"
@@ -169,4 +170,13 @@ func TestScript_GetPublicKeyHash(t *testing.T) {
 		assert.Error(t, err)
 		assert.EqualError(t, err, "script is empty")
 	})
+}
+
+func TestErrorIsAppended(t *testing.T) {
+	script, _ := hex.DecodeString("6a0548656c6c6f0548656c6c")
+	s := bscript.Script(script)
+
+	asm, err := s.ToASM()
+	assert.NoError(t, err)
+	assert.True(t, strings.HasSuffix(asm, "[error]"), "toASM() should end with [error]")
 }


### PR DESCRIPTION
In order to function like bitcoin node, ToASM() will append [error] to script rather than return an error.