### PR TITLE
Added a func to return the TXID of a transaction as a byte slice.

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -378,6 +378,12 @@ func (tx *Tx) GetTotalOutputSatoshis() (total uint64) {
 	return
 }
 
+// GetTxIDAsBytes returns the transaction ID of the transaction as bytes
+// (which is also the transaction hash).
+func (tx *Tx) GetTxIDAsBytes() []byte {
+	return ReverseBytes(crypto.Sha256d(tx.ToBytes()))
+}
+
 // GetTxID returns the transaction ID of the transaction
 // (which is also the transaction hash).
 func (tx *Tx) GetTxID() string {


### PR DESCRIPTION
This was requested to avoid unnecessary conversion to hex string and then back again for callers that want to store 32 bytes rather than 64 characters.  I am assuming the bytes should be reversed as they are in the GetTxID() function.