### PR TITLE
ChangeToOutput

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -347,7 +347,6 @@ linters:
     - exhaustive
     - sqlclosecheck
     - nolintlint
-    - gci
     - goconst
     - lll
   disable:

--- a/bscript/address.go
+++ b/bscript/address.go
@@ -77,7 +77,7 @@ func NewAddressFromPublicKeyHash(hash []byte, mainnet bool) (*Address, error) {
 	if !mainnet {
 		bb[0] = 111
 	}
-
+	// nolint:makezero // stop complaining
 	bb = append(bb, hash...)
 
 	return &Address{
@@ -99,7 +99,7 @@ func NewAddressFromPublicKey(pubKey *bsvec.PublicKey, mainnet bool) (*Address, e
 	if !mainnet {
 		bb[0] = 111
 	}
-
+	// nolint:makezero // stop complaining
 	bb = append(bb, hash...)
 
 	return &Address{

--- a/tx.go
+++ b/tx.go
@@ -260,6 +260,19 @@ func (tx *Tx) ChangeToOutput(index uint, f []*Fee) error {
 	return nil
 }
 
+// CalculateFee will return the amount of fees the current transaction will
+// require.
+func (tx *Tx) CalculateFee(f []*Fee) (uint64, error) {
+	total := tx.GetTotalInputSatoshis() - tx.GetTotalOutputSatoshis()
+	sats, _, err := tx.change(nil, f, false)
+	if err != nil {
+		return 0, err
+	}
+	return total - sats, nil
+}
+
+// change will return the amount of satoshis to add to an input after fees are removed.
+// True will be returned if change has been added.
 func (tx *Tx) change(s *bscript.Script, f []*Fee, newOutput bool) (uint64, bool, error) {
 	inputAmount := tx.GetTotalInputSatoshis()
 	outputAmount := tx.GetTotalOutputSatoshis()

--- a/tx.go
+++ b/tx.go
@@ -247,7 +247,7 @@ func (tx *Tx) Change(s *bscript.Script, f []*Fee) error {
 // ChangeToOutput will calculate fees and add them to an output at the index specified (0 based).
 // If an invalid index is supplied and error is returned.
 func (tx *Tx) ChangeToOutput(index uint, f []*Fee) error {
-	if len(tx.Outputs)-1 > int(index) {
+	if int(index) > len(tx.Outputs)-1 {
 		return errors.New("index is greater than number of inputs in transaction")
 	}
 	available, hasChange, err := tx.change(tx.Outputs[index].LockingScript, f, false)

--- a/tx_test.go
+++ b/tx_test.go
@@ -851,3 +851,50 @@ func TestTx_ChangeToOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestTx_CalculateChange(t *testing.T) {
+	tests := map[string]struct {
+		tx      *bt.Tx
+		fees    []*bt.Fee
+		expFees uint64
+		err     error
+	}{
+		"Transaction with one input one output should return 96": {
+			tx: func() *bt.Tx {
+				tx := bt.NewTx()
+				assert.NoError(t, tx.From(
+					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
+					0,
+					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
+					1000))
+				assert.NoError(t, tx.PayTo("mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500))
+				return tx
+			}(),
+			fees:    bt.DefaultFees(),
+			expFees: 96,
+		}, "Transaction with one input 4 outputs should return 147": {
+			tx: func() *bt.Tx {
+				tx := bt.NewTx()
+				assert.NoError(t, tx.From(
+					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
+					0,
+					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
+					2500))
+				assert.NoError(t, tx.PayTo("mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500))
+				assert.NoError(t, tx.PayTo("mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500))
+				assert.NoError(t, tx.PayTo("mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500))
+				assert.NoError(t, tx.PayTo("mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500))
+				return tx
+			}(),
+			fees:    bt.DefaultFees(),
+			expFees: 147,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fee, err := test.tx.CalculateFee(test.fees)
+			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.expFees, fee)
+		})
+	}
+}


### PR DESCRIPTION
This can be used to append change to an existing output rather than adding a new output, this can help reduce transaction fees slightly.

Added new CalculateFees method also.