### PR TITLE
Marshal/ Unmarshal feeQuote

### DIFF
--- a/fees_test.go
+++ b/fees_test.go
@@ -589,7 +589,7 @@ func TestFeeQuote_MarshalUnmarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("unknown fee type supplied ''"),
+			err: errors.New("unknown feetype supplied ''"),
 		}, "random key should error": {
 			quote: &FeeQuote{
 				fees: map[FeeType]*Fee{
@@ -605,7 +605,7 @@ func TestFeeQuote_MarshalUnmarshalJSON(t *testing.T) {
 					},
 				},
 			},
-			err: errors.New("unknown fee type supplied 'idunno'"),
+			err: errors.New("unknown feetype supplied 'idunno'"),
 		},
 	}
 	for name, test := range tests {

--- a/fees_test.go
+++ b/fees_test.go
@@ -1,6 +1,8 @@
 package bt
 
 import (
+	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -536,6 +538,87 @@ func TestFeeQuotes_Fee(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, fee)
 			assert.Equal(t, test.expFee, fee)
+		})
+	}
+}
+
+func TestFeeQuote_MarshalUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+	tests := map[string]struct {
+		quote *FeeQuote
+		err   error
+	}{
+		"successful run should return no errors": {
+			quote: &FeeQuote{
+				fees: map[FeeType]*Fee{
+					FeeTypeStandard: {
+						FeeType: FeeTypeStandard,
+						MiningFee: FeeUnit{
+							Satoshis: 100,
+							Bytes:    10,
+						},
+						RelayFee: FeeUnit{
+							Satoshis: 10,
+							Bytes:    5},
+					}, FeeTypeData: {
+						FeeType: FeeTypeData,
+						MiningFee: FeeUnit{
+							Satoshis: 5,
+							Bytes:    2,
+						},
+						RelayFee: FeeUnit{
+							Satoshis: 8,
+							Bytes:    4},
+					},
+				},
+			},
+			err: nil,
+		},
+		"empty key should error": {
+			quote: &FeeQuote{
+				fees: map[FeeType]*Fee{
+					"": {
+						FeeType: FeeTypeStandard,
+						MiningFee: FeeUnit{
+							Satoshis: 100,
+							Bytes:    10,
+						},
+						RelayFee: FeeUnit{
+							Satoshis: 10,
+							Bytes:    5},
+					},
+				},
+			},
+			err: errors.New("unknown fee type supplied ''"),
+		}, "random key should error": {
+			quote: &FeeQuote{
+				fees: map[FeeType]*Fee{
+					"idunno": {
+						FeeType: FeeTypeStandard,
+						MiningFee: FeeUnit{
+							Satoshis: 100,
+							Bytes:    10,
+						},
+						RelayFee: FeeUnit{
+							Satoshis: 10,
+							Bytes:    5},
+					},
+				},
+			},
+			err: errors.New("unknown fee type supplied 'idunno'"),
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			bb, _ := json.Marshal(test.quote)
+			var quote *FeeQuote
+			err := json.Unmarshal(bb, &quote)
+			if test.err != nil {
+				assert.Error(t, err)
+				assert.EqualError(t, err, test.err.Error())
+				return
+			}
+			assert.Equal(t, test.quote, quote)
 		})
 	}
 }


### PR DESCRIPTION
Adding marshal and unmarshal methods to the FeeQuote type including unit tests, this will convert between a FeeQuote type and JSON with the following format:

```json
{
	"data": {
		"miningFee": {
			"satoshis": 5,
			"bytes": 2
		},
		"relayFee": {
			"satoshis": 8,
			"bytes": 4
		}
	},
	"standard": {
		"miningFee": {
			"satoshis": 100,
			"bytes": 10
		},
		"relayFee": {
			"satoshis": 10,
			"bytes": 5
		}
	}
}
```