### PR TITLE
Fix: False positive with IsFeePaidEnough

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -413,7 +413,14 @@ func (tx *Tx) IsFeePaidEnough(fees *FeeQuote) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	actualFeePaid := tx.TotalInputSatoshis() - tx.TotalOutputSatoshis()
+	totalInputSatoshis := tx.TotalInputSatoshis()
+	totalOutputSatoshis := tx.TotalOutputSatoshis()
+
+	if totalInputSatoshis < totalOutputSatoshis {
+		return false, nil
+	}
+
+	actualFeePaid := totalInputSatoshis - totalOutputSatoshis
 	return actualFeePaid >= expFeesPaid.TotalFeePaid, nil
 }
 


### PR DESCRIPTION
I'm looking to fund by way of:
```
	feesPaid, err := tx.IsFeePaidEnough(fq)
	if err != nil {
		return nil, err
	}
	for i := 0; !feesPaid && i < len(ff); i++ {
		f := ff[i]
		if err := tx.From(f.TxID, f.Vout, f.LockingScript, f.Satoshis); err != nil {
			return nil, err
		}

		feesPaid, err = tx.IsFeePaidEnough(fq)
		if err != nil {
			return nil, err
		}
	}
	if !feesPaid {
		return nil, errors.New("not enough funds")
	}
```

However, given that the `TotalInputSatoshis` func returns a `uint64`, once it gets a larger number subtracted from itself, it underflows to INT_MAX, causing the first call of `IsFeePaidEnough` to return `true`.