### PR TITLE
Feature: JSON Marshalling and Unmarshalling for bt.UTXO

### DIFF
--- a/utxo.go
+++ b/utxo.go
@@ -19,7 +19,7 @@ type utxoJSON struct {
 	TxID         string  `json:"txid"`
 	Vout         uint32  `json:"vout"`
 	ScriptPubKey string  `json:"scriptPubKey"`
-	Amount       float64 `json:"amount"`
+	Value        float64 `json:"value"`
 	Satoshis     uint64  `json:"satoshis"`
 }
 
@@ -46,7 +46,7 @@ func (u *UTXO) UnmarshalJSON(body []byte) error {
 	if j.Satoshis > 0 {
 		u.Satoshis = j.Satoshis
 	} else {
-		u.Satoshis = uint64(j.Amount * 100000000)
+		u.Satoshis = uint64(j.Value * 100000000)
 	}
 
 	return nil
@@ -56,7 +56,7 @@ func (u *UTXO) UnmarshalJSON(body []byte) error {
 func (u *UTXO) MarshalJSON() ([]byte, error) {
 	return json.Marshal(utxoJSON{
 		TxID:         hex.EncodeToString(u.TxID),
-		Amount:       float64(u.Satoshis) / 100000000,
+		Value:        float64(u.Satoshis) / 100000000,
 		Satoshis:     u.Satoshis,
 		Vout:         u.Vout,
 		ScriptPubKey: u.LockingScript.String(),

--- a/utxo.go
+++ b/utxo.go
@@ -1,6 +1,11 @@
 package bt
 
-import "github.com/libsv/go-bt/v2/bscript"
+import (
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/libsv/go-bt/v2/bscript"
+)
 
 // UTXO an unspent transaction output, used for creating inputs
 type UTXO struct {
@@ -8,4 +13,52 @@ type UTXO struct {
 	Vout          uint32
 	LockingScript *bscript.Script
 	Satoshis      uint64
+}
+
+type utxoJSON struct {
+	TxID         string  `json:"txid"`
+	Vout         uint32  `json:"vout"`
+	ScriptPubKey string  `json:"scriptPubKey"`
+	Amount       float64 `json:"amount"`
+	Satoshis     uint64  `json:"satoshis"`
+}
+
+// UnmarshalJSON will convert a json serialised utxo to a bt.UTXO.
+func (u *UTXO) UnmarshalJSON(body []byte) error {
+	var j utxoJSON
+	if err := json.Unmarshal(body, &j); err != nil {
+		return err
+	}
+
+	txID, err := hex.DecodeString(j.TxID)
+	if err != nil {
+		return err
+	}
+
+	ls, err := bscript.NewFromHexString(j.ScriptPubKey)
+	if err != nil {
+		return err
+	}
+
+	u.TxID = txID
+	u.LockingScript = ls
+	u.Vout = j.Vout
+	if j.Satoshis > 0 {
+		u.Satoshis = j.Satoshis
+	} else {
+		u.Satoshis = uint64(j.Amount * 100000000)
+	}
+
+	return nil
+}
+
+// MarshalJSON will serialise a utxo to json.
+func (u *UTXO) MarshalJSON() ([]byte, error) {
+	return json.Marshal(utxoJSON{
+		TxID:         hex.EncodeToString(u.TxID),
+		Amount:       float64(u.Satoshis) / 100000000,
+		Satoshis:     u.Satoshis,
+		Vout:         u.Vout,
+		ScriptPubKey: u.LockingScript.String(),
+	})
 }

--- a/utxo_test.go
+++ b/utxo_test.go
@@ -1,0 +1,83 @@
+package bt_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/libsv/go-bt/v2"
+	"github.com/libsv/go-bt/v2/bscript"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUTXO_JSON(t *testing.T) {
+	tests := map[string]struct {
+		utxo *bt.UTXO
+	}{
+		"standard utxo should marshal and unmarshal correctly": {
+			utxo: func() *bt.UTXO {
+				txID, err := hex.DecodeString("31ad4b5ef1d0d48340e063087cbfa6a3f3dea3cd5d34c983e0028c18daf3d2a7")
+				assert.NoError(t, err)
+				script, err := bscript.NewFromHexString("2102076ad7c107f82ae973fbdaa1d84532c8d69e3838bcbee1570efe0fa30b3cb25bac")
+				assert.NoError(t, err)
+				return &bt.UTXO{
+					TxID:          txID,
+					LockingScript: script,
+					Satoshis:      1250000000,
+					Vout:          0,
+				}
+			}(),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			bb, err := json.Marshal(test.utxo)
+			assert.NoError(t, err)
+
+			var utxo *bt.UTXO
+			assert.NoError(t, json.Unmarshal(bb, &utxo))
+
+			bb2, err := json.Marshal(utxo)
+			assert.NoError(t, err)
+			assert.Equal(t, bb, bb2)
+		})
+	}
+}
+
+func TestUTXO_MarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		utxo *bt.UTXO
+		exp  string
+	}{
+		"standard utxo should marshal correctly": {
+			utxo: func() *bt.UTXO {
+				txID, err := hex.DecodeString("31ad4b5ef1d0d48340e063087cbfa6a3f3dea3cd5d34c983e0028c18daf3d2a7")
+				assert.NoError(t, err)
+				script, err := bscript.NewFromHexString("2102076ad7c107f82ae973fbdaa1d84532c8d69e3838bcbee1570efe0fa30b3cb25bac")
+				assert.NoError(t, err)
+				return &bt.UTXO{
+					TxID:          txID,
+					LockingScript: script,
+					Satoshis:      1250000000,
+					Vout:          0,
+				}
+			}(),
+			exp: `{
+    "txid": "31ad4b5ef1d0d48340e063087cbfa6a3f3dea3cd5d34c983e0028c18daf3d2a7",
+    "vout": 0,
+    "scriptPubKey": "2102076ad7c107f82ae973fbdaa1d84532c8d69e3838bcbee1570efe0fa30b3cb25bac",
+    "amount": 12.5,
+    "satoshis": 1250000000
+}`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			bb, err := json.MarshalIndent(test.utxo, "", "    ")
+			assert.NoError(t, err)
+
+			assert.Equal(t, test.exp, string(bb))
+		})
+	}
+}

--- a/utxo_test.go
+++ b/utxo_test.go
@@ -67,7 +67,7 @@ func TestUTXO_MarshalJSON(t *testing.T) {
     "txid": "31ad4b5ef1d0d48340e063087cbfa6a3f3dea3cd5d34c983e0028c18daf3d2a7",
     "vout": 0,
     "scriptPubKey": "2102076ad7c107f82ae973fbdaa1d84532c8d69e3838bcbee1570efe0fa30b3cb25bac",
-    "amount": 12.5,
+    "value": 12.5,
     "satoshis": 1250000000
 }`,
 		},


### PR DESCRIPTION
Keynames were chosen out of regtest compatibility, specifically around `listunspent`.