### PR TITLE
Fix: Use varadic call internally

### DIFF
--- a/txinput.go
+++ b/txinput.go
@@ -168,10 +168,8 @@ func (tx *Tx) Fund(ctx context.Context, fq *FeeQuote, next UTXOGetterFunc) error
 			return err
 		}
 
-		for _, utxo := range utxos {
-			if err = tx.FromUTXOs(utxo); err != nil {
-				return err
-			}
+		if err = tx.FromUTXOs(utxos...); err != nil {
+			return err
 		}
 
 		deficit, err = tx.estimateDeficit(fq)


### PR DESCRIPTION
There's no point iterating the utxos in `tx.Fund` and passing them into `FromUTXOs` when we can just pass them in at once.