### PR TITLE
Fix: Inputs/Outputs in isolation

### DIFF
--- a/input_test.go
+++ b/input_test.go
@@ -1,10 +1,9 @@
-package bt_test
+package bt
 
 import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/libsv/go-bt/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,33 +15,33 @@ func TestNewInputFromBytes(t *testing.T) {
 		b, err := hex.DecodeString(rawHex)
 		assert.NoError(t, err)
 
-		var i *bt.Input
+		var i *Input
 		var s int
-		i, s, err = bt.NewInputFromBytes(b)
+		i, s, err = newInputFromBytes(b)
 		assert.NoError(t, err)
 		assert.NotNil(t, i)
 		assert.Equal(t, 148, s)
 		assert.Equal(t, uint32(1), i.PreviousTxOutIndex)
 		assert.Equal(t, 107, len(*i.UnlockingScript))
-		assert.Equal(t, bt.DefaultSequenceNumber, i.SequenceNumber)
+		assert.Equal(t, DefaultSequenceNumber, i.SequenceNumber)
 	})
 
 	t.Run("empty bytes", func(t *testing.T) {
-		i, s, err := bt.NewInputFromBytes([]byte(""))
+		i, s, err := newInputFromBytes([]byte(""))
 		assert.Error(t, err)
 		assert.Nil(t, i)
 		assert.Equal(t, 0, s)
 	})
 
 	t.Run("invalid input, too short", func(t *testing.T) {
-		i, s, err := bt.NewInputFromBytes([]byte("invalid"))
+		i, s, err := newInputFromBytes([]byte("invalid"))
 		assert.Error(t, err)
 		assert.Nil(t, i)
 		assert.Equal(t, 0, s)
 	})
 
 	t.Run("invalid input, too short + script", func(t *testing.T) {
-		i, s, err := bt.NewInputFromBytes([]byte("000000000000000000000000000000000000000000000000000000000000000000000000"))
+		i, s, err := newInputFromBytes([]byte("000000000000000000000000000000000000000000000000000000000000000000000000"))
 		assert.Error(t, err)
 		assert.Nil(t, i)
 		assert.Equal(t, 0, s)
@@ -55,9 +54,9 @@ func TestInput_String(t *testing.T) {
 		b, err := hex.DecodeString(rawHex)
 		assert.NoError(t, err)
 
-		var i *bt.Input
+		var i *Input
 		var s int
-		i, s, err = bt.NewInputFromBytes(b)
+		i, s, err = newInputFromBytes(b)
 		assert.NoError(t, err)
 		assert.NotNil(t, i)
 		assert.Equal(t, 148, s)

--- a/output_test.go
+++ b/output_test.go
@@ -1,12 +1,10 @@
-package bt_test
+package bt
 
 import (
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/libsv/go-bt/v2"
 )
 
 const outputHexStr = "8a08ac4a000000001976a9148bf10d323ac757268eb715e613cb8e8e1d1793aa88ac00000000"
@@ -15,14 +13,14 @@ func TestNewOutputFromBytes(t *testing.T) {
 	t.Parallel()
 
 	t.Run("invalid output, too short", func(t *testing.T) {
-		o, s, err := bt.NewOutputFromBytes([]byte(""))
+		o, s, err := newOutputFromBytes([]byte(""))
 		assert.Error(t, err)
 		assert.Nil(t, o)
 		assert.Equal(t, 0, s)
 	})
 
 	t.Run("invalid output, too short + script", func(t *testing.T) {
-		o, s, err := bt.NewOutputFromBytes([]byte("0000000000000"))
+		o, s, err := newOutputFromBytes([]byte("0000000000000"))
 		assert.Error(t, err)
 		assert.Nil(t, o)
 		assert.Equal(t, 0, s)
@@ -32,9 +30,9 @@ func TestNewOutputFromBytes(t *testing.T) {
 		bytes, err := hex.DecodeString(outputHexStr)
 		assert.NoError(t, err)
 
-		var o *bt.Output
+		var o *Output
 		var s int
-		o, s, err = bt.NewOutputFromBytes(bytes)
+		o, s, err = newOutputFromBytes(bytes)
 		assert.NoError(t, err)
 		assert.NotNil(t, o)
 
@@ -51,8 +49,8 @@ func TestOutput_String(t *testing.T) {
 		bytes, err := hex.DecodeString(outputHexStr)
 		assert.NoError(t, err)
 
-		var o *bt.Output
-		o, _, err = bt.NewOutputFromBytes(bytes)
+		var o *Output
+		o, _, err = newOutputFromBytes(bytes)
 		assert.NoError(t, err)
 		assert.NotNil(t, o)
 

--- a/tx.go
+++ b/tx.go
@@ -174,7 +174,7 @@ func NewTxFromStream(b []byte) (*Tx, int, error) {
 	var err error
 	var input *Input
 	for ; i < inputCount; i++ {
-		input, size, err = NewInputFromBytes(b[offset:])
+		input, size, err = newInputFromBytes(b[offset:])
 		if err != nil {
 			return nil, 0, err
 		}
@@ -188,7 +188,7 @@ func NewTxFromStream(b []byte) (*Tx, int, error) {
 	outputCount, size = DecodeVarInt(b[offset:])
 	offset += size
 	for i = 0; i < outputCount; i++ {
-		output, size, err = NewOutputFromBytes(b[offset:])
+		output, size, err = newOutputFromBytes(b[offset:])
 		if err != nil {
 			return nil, 0, err
 		}

--- a/txinput.go
+++ b/txinput.go
@@ -30,8 +30,8 @@ var (
 // It is expected that bt.ErrNoUTXO will be returned once the utxo source is depleted.
 type UTXOGetterFunc func(ctx context.Context, deficit uint64) ([]*UTXO, error)
 
-// NewInputFromBytes returns a transaction input from the bytes provided.
-func NewInputFromBytes(bytes []byte) (*Input, int, error) {
+// newInputFromBytes returns a transaction input from the bytes provided.
+func newInputFromBytes(bytes []byte) (*Input, int, error) {
 	if len(bytes) < 36 {
 		return nil, 0, fmt.Errorf("input length too short < 36")
 	}

--- a/txoutput.go
+++ b/txoutput.go
@@ -11,8 +11,8 @@ import (
 	"github.com/libsv/go-bt/v2/bscript"
 )
 
-// NewOutputFromBytes returns a transaction Output from the bytes provided
-func NewOutputFromBytes(bytes []byte) (*Output, int, error) {
+// newOutputFromBytes returns a transaction Output from the bytes provided
+func newOutputFromBytes(bytes []byte) (*Output, int, error) {
 	if len(bytes) < 8 {
 		return nil, 0, fmt.Errorf("output length too short < 8")
 	}


### PR DESCRIPTION
Resolves #47 

Move towards the removal/unexportation of any function which builds and returns an input or output, in order to prevent accidental misuse. Currently, the last ones left (that I could find) are `NewInputFromBytes` and `NewOutputFromBytes`.