### PR TITLE
Enhancement: JSON Marshalling of *bscript.Script

### DIFF
--- a/bscript/script.go
+++ b/bscript/script.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"strings"
 
 	"github.com/libsv/go-bk/bec"
@@ -393,4 +394,20 @@ func (s *Script) EqualsBytes(b []byte) bool {
 // if they match then true is returned otherwise false.
 func (s *Script) EqualsHex(h string) bool {
 	return s.String() == h
+}
+
+// MarshalJSON convert script into json.
+func (s *Script) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`"%s"`, s.String())), nil
+}
+
+// UnmarshalJSON covert from json into *bscript.Script.
+func (s *Script) UnmarshalJSON(bb []byte) error {
+	ss, err := NewFromHexString(string(bb))
+	if err != nil {
+		return err
+	}
+
+	*s = *ss
+	return nil
 }

--- a/bscript/script.go
+++ b/bscript/script.go
@@ -403,7 +403,7 @@ func (s *Script) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON covert from json into *bscript.Script.
 func (s *Script) UnmarshalJSON(bb []byte) error {
-	ss, err := NewFromHexString(string(bb))
+	ss, err := NewFromHexString(string(bytes.Trim(bb, `"`)))
 	if err != nil {
 		return err
 	}

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -3,6 +3,7 @@ package bscript_test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -285,6 +286,40 @@ func TestScript_Equals(t *testing.T) {
 			assert.Equal(t, test.exp, test.script1.Equals(test.script2))
 			assert.Equal(t, test.exp, test.script1.EqualsBytes(*test.script2))
 			assert.Equal(t, test.exp, test.script1.EqualsHex(test.script2.String()))
+		})
+	}
+}
+
+func TestScript_MarshalJSON(t *testing.T) {
+	script, err := bscript.NewFromASM("OP_2 OP_2 OP_ADD OP_4 OP_EQUALVERIFY")
+	assert.NoError(t, err)
+
+	bb, err := json.Marshal(script)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `"5252935488"`, string(bb))
+}
+
+func TestScript_UnmarshalJSON(t *testing.T) {
+	tests := map[string]struct {
+		jsonString string
+		exp        string
+	}{
+		"script with content": {
+			jsonString: `"5252935488"`,
+			exp:        "5252935488",
+		},
+		"empty script": {
+			jsonString: `""`,
+			exp:        "",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var out bscript.Script
+			assert.NoError(t, json.Unmarshal([]byte(test.jsonString), &out))
+			assert.Equal(t, test.exp, out.String())
 		})
 	}
 }

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -317,7 +317,7 @@ func TestScript_UnmarshalJSON(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			var out bscript.Script
+			var out *bscript.Script
 			assert.NoError(t, json.Unmarshal([]byte(test.jsonString), &out))
 			assert.Equal(t, test.exp, out.String())
 		})


### PR DESCRIPTION
Currently our bscripts, when marshalled into JSON, marshal into byte arrays, which causes output to be base64-ified.

Adding a marshaller and an unmarshaller to allow marshalling to and from hex strings.