### PR TITLE
Enhancement: ReadFrom for bt.Txs

### DIFF
--- a/examples/read_txs_from_block/read_txs_from_block.go
+++ b/examples/read_txs_from_block/read_txs_from_block.go
@@ -25,7 +25,7 @@ func main() {
 	// Create buffered reader for this file.
 	r := bufio.NewReader(f)
 
-	// Read file header. This is step is specific to file reading and
+	// Read file header. This step is specific to file reading and
 	// may need omitted or modified for other implentations.
 	_, err = io.ReadFull(f, make([]byte, 80))
 	if err != nil {

--- a/examples/read_txs_from_block/read_txs_from_block.go
+++ b/examples/read_txs_from_block/read_txs_from_block.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/libsv/go-bt/v2"
+)
+
+// In this example, all txs from a block are being read in via chunking, so at no point
+// does the entire block have to be held in memory, and instead can be streamed.
+//
+// We represent the block by interatively reading a file, however it could be any data
+// stream that satisfies the io.Reader interface.
+
+func main() {
+	// Open file container block data.
+	f, err := os.Open("testing/data/tx/bin/block.bin")
+	if err != nil {
+		panic(err)
+	}
+
+	// Create buffered reader for this file.
+	r := bufio.NewReader(f)
+
+	// Read file header. This is step is specific to file reading and
+	// may need omitted or modified for other implentations.
+	_, err = io.ReadFull(f, make([]byte, 80))
+	if err != nil {
+		panic(err)
+	}
+
+	txs := bt.Txs{}
+	if _, err = txs.ReadFrom(r); err != nil {
+		panic(err)
+	}
+	for _, tx := range txs {
+		fmt.Println(tx.TxID())
+	}
+}

--- a/tx.go
+++ b/tx.go
@@ -189,6 +189,34 @@ func (tx *Tx) ReadFrom(r io.Reader) (int64, error) {
 	return bytesRead, nil
 }
 
+// ReadFrom txs from a block in a `bt.Txs`. This assumes a preceeding varint detailing
+// the total number of txs that the reader will provide.
+func (tt *Txs) ReadFrom(r io.Reader) (int64, error) {
+	var bytesRead int64
+
+	var txCount VarInt
+	n, err := txCount.ReadFrom(r)
+	bytesRead += n
+	if err != nil {
+		return bytesRead, err
+	}
+
+	*tt = make([]*Tx, txCount)
+
+	for i := int64(0); i < int64(txCount); i++ {
+		tx := new(Tx)
+		n, err := tx.ReadFrom(r)
+		bytesRead += n
+		if err != nil {
+			return bytesRead, err
+		}
+
+		(*tt)[i] = tx
+	}
+
+	return bytesRead, nil
+}
+
 // HasDataOutputs returns true if the transaction has
 // at least one data (OP_RETURN) output in it.
 func (tx *Tx) HasDataOutputs() bool {

--- a/tx.go
+++ b/tx.go
@@ -203,7 +203,7 @@ func (tt *Txs) ReadFrom(r io.Reader) (int64, error) {
 
 	*tt = make([]*Tx, txCount)
 
-	for i := int64(0); i < int64(txCount); i++ {
+	for i := uint64(0); i < uint64(txCount); i++ {
 		tx := new(Tx)
 		n, err := tx.ReadFrom(r)
 		bytesRead += n

--- a/tx.go
+++ b/tx.go
@@ -189,7 +189,7 @@ func (tx *Tx) ReadFrom(r io.Reader) (int64, error) {
 	return bytesRead, nil
 }
 
-// ReadFrom txs from a block in a `bt.Txs`. This assumes a preceeding varint detailing
+// ReadFrom txs from a block in a `bt.Txs`. This assumes a preceding varint detailing
 // the total number of txs that the reader will provide.
 func (tt *Txs) ReadFrom(r io.Reader) (int64, error) {
 	var bytesRead int64

--- a/tx_test.go
+++ b/tx_test.go
@@ -1167,3 +1167,26 @@ func TestTx_ReadFrom(t *testing.T) {
 	assert.Equal(t, "b7c59d7fa17a74bbe0a05e5381f42b9ac7fe23b8a1ca40005a74802fe5b8bb5a", tx.TxID())
 	assert.Equal(t, int64(340216), bytesRead)
 }
+
+func TestTxs_ReadFrom(t *testing.T) {
+	f, err := data.TxBinData.Open("block.bin")
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+	}()
+	assert.NoError(t, err)
+
+	r := bufio.NewReader(f)
+
+	header := make([]byte, 80)
+	_, err = io.ReadFull(f, header)
+	assert.NoError(t, err)
+
+	txs := bt.Txs{}
+	bytesRead, err := txs.ReadFrom(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "b7c59d7fa17a74bbe0a05e5381f42b9ac7fe23b8a1ca40005a74802fe5b8bb5a", txs[len(txs)-1].TxID())
+	assert.Equal(t, int64(340219), bytesRead)
+}


### PR DESCRIPTION
Added `ReadFrom` to the `bt.Txs` type, along with an example on how to use, to further abstract the chunking of a binary block.

This way users don't need to worry about the varint or tracking their progression through a byte stream.