### PR TITLE
Enhancement: Expose FeeQuote expiry time

### DIFF
--- a/fees.go
+++ b/fees.go
@@ -200,7 +200,7 @@ func (f *FeeQuote) AddQuote(ft FeeType, fee *Fee) *FeeQuote {
 	return f
 }
 
-// Expired will return the expiry timestamp for the `bt.FeeQuote` in a threadsafe manner.
+// Expiry will return the expiry timestamp for the `bt.FeeQuote` in a threadsafe manner.
 func (f *FeeQuote) Expiry() time.Time {
 	f.mu.RLock()
 	defer f.mu.RUnlock()

--- a/fees.go
+++ b/fees.go
@@ -200,6 +200,13 @@ func (f *FeeQuote) AddQuote(ft FeeType, fee *Fee) *FeeQuote {
 	return f
 }
 
+// Expired will return the expiry timestamp for the `bt.FeeQuote` in a threadsafe manner.
+func (f *FeeQuote) Expiry() time.Time {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.expiryTime
+}
+
 // UpdateExpiry will update the expiry time of the quotes, this will be
 // used when you fetch a fresh set of quotes from a MAPI server which
 // should return an expiration time.

--- a/fees_test.go
+++ b/fees_test.go
@@ -81,6 +81,13 @@ func TestFeeQuote_Expired(t *testing.T) {
 	assert.True(t, fq.Expired())
 }
 
+func TestFeeQuote_Expiry(t *testing.T) {
+	ts := time.Now().Add(1 * time.Hour)
+	fq := NewFeeQuote()
+	fq.UpdateExpiry(ts)
+	assert.Equal(t, ts, fq.Expiry())
+}
+
 func TestFeeQuote_AddQuote(t *testing.T) {
 	std := &Fee{
 		FeeType: FeeTypeStandard,


### PR DESCRIPTION
Certain usecases of a feequote may include wanting to know when a fee expires, as opposed to just if it is currently expired.

This function allows for that.