### PR TITLE
Enhancement: VarInt length

### DIFF
--- a/varint.go
+++ b/varint.go
@@ -28,6 +28,20 @@ func NewVarIntFromBytes(bb []byte) (VarInt, int) {
 	}
 }
 
+// Length return the length of the underlying byte representation of the `bt.VarInt`.
+func (v VarInt) Length() int {
+	if v < 253 {
+		return 1
+	}
+	if v < 65536 {
+		return 3
+	}
+	if v < 4294967296 {
+		return 5
+	}
+	return 9
+}
+
 // Bytes takes the underlying unsigned integer and returns a byte array in VarInt format.
 // See http://learnmeabitcoin.com/glossary/varint
 func (v VarInt) Bytes() []byte {

--- a/varint_test.go
+++ b/varint_test.go
@@ -90,3 +90,41 @@ func TestVarInt(t *testing.T) {
 		})
 	}
 }
+
+func TestVarInt_Size(t *testing.T) {
+	tests := map[string]struct {
+		v       bt.VarInt
+		expSize int
+	}{
+		"252 returns 1": {
+			v:       bt.VarInt(252),
+			expSize: 1,
+		},
+		"253 returns 3": {
+			v:       bt.VarInt(253),
+			expSize: 3,
+		},
+		"65535 returns 3": {
+			v:       bt.VarInt(65535),
+			expSize: 3,
+		},
+		"65536 returns 5": {
+			v:       bt.VarInt(65536),
+			expSize: 5,
+		},
+		"4294967295 returns 5": {
+			v:       bt.VarInt(4294967295),
+			expSize: 5,
+		},
+		"4294967296 returns 9": {
+			v:       bt.VarInt(4294967296),
+			expSize: 9,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expSize, test.v.Length())
+		})
+	}
+}


### PR DESCRIPTION
Currently the only way to get the lenght of a `bt.VarInt` is from creating a new one from bytes, or by calling `len(v.Bytes())`.

I've added a `Length() int` func which works out and returns this size without having to convert the varint into a byte slice.