### PR TITLE
Added check for nonstandard short script when parsing PublicKeyHash

### DIFF
--- a/bscript/script.go
+++ b/bscript/script.go
@@ -336,7 +336,7 @@ func (s *Script) PublicKeyHash() ([]byte, error) {
 		return nil, ErrEmptyScript
 	}
 
-	if (*s)[0] != OpDUP || (*s)[1] != OpHASH160 {
+	if (*s)[0] != OpDUP || len(*s) <= 2 || (*s)[1] != OpHASH160 {
 		return nil, ErrNotP2PKH
 	}
 

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -236,6 +236,17 @@ func TestScript_PublicKeyHash(t *testing.T) {
 		assert.Error(t, err)
 		assert.EqualError(t, err, "script is empty")
 	})
+
+	t.Run("nonstandard script", func(t *testing.T) {
+		// example tx 37d4cc9f8a3b62e7f2e7c97c07a3282bfa924739c0e174733ff1b764ef8e3ebc
+		s, err := bscript.NewFromHexString("76")
+		assert.NoError(t, err)
+		assert.NotNil(t, s)
+
+		_, err = s.PublicKeyHash()
+		assert.Error(t, err)
+		assert.EqualError(t, err, "not a P2PKH")
+	})
 }
 
 func TestErrorIsAppended(t *testing.T) {


### PR DESCRIPTION
Checks in PublicKeyHash fail for nonstandard scripts `panic: runtime error: index out of range [1] with length 1`

Added test from example tx which failed in one of my projects.