### PR TITLE
Add conditional break in parsing the script after op return…

### DIFF
--- a/bscript/interpreter/opcodeparser.go
+++ b/bscript/interpreter/opcodeparser.go
@@ -159,7 +159,7 @@ func (p *DefaultOpcodeParser) Parse(s *bscript.Script) (ParsedScript, error) {
 				return parsedOps, nil
 			}
 			// If we are in an conditional block, we continue parsing the other branches,
-			// therefore all data must adhere to push datat rules.
+			// therefore all data must adhere to push data rules.
 		}
 
 		switch {


### PR DESCRIPTION
…so long as we are not in a conditional block.

This is to get the library in line with v1.0.15.1 of SV node as outlined within this issue: https://github.com/bitcoin-sv/bitcoin-sv/issues/296

Logic should match SV node here: https://github.com/bitcoin-sv/bitcoin-sv/blob/89d55a8ddb0e29f4786e11efad1e92cdefd0b9c5/src/script/script.cpp#L38